### PR TITLE
Memorable no redundant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-tools",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "index.js",
   "module": "index.js",
   "svelte": "index.js",

--- a/src/lib/memorable/index.ts
+++ b/src/lib/memorable/index.ts
@@ -7,8 +7,8 @@ export function memorable<T>(value: T, capacity = 1): Memorable<T> {
 
     const store = writable([value, ...Array(capacity).fill(value)])
 
-    const memorize = (oldMemories, newMemory, max = capacity) => [newMemory, ...oldMemories].slice(0, max + 1)
-
+    const memorize = (oldMemories, newMemory, max = capacity) => Array.from(new Set([newMemory, ...oldMemories])).slice(0, max + 1)
+    
     const current = {
         set: (val: T) => store.update((values) => memorize(values, val)),
         update: (fn: Updater<T>) => store.update(values => memorize(values, fn(values[0]))),


### PR DESCRIPTION
filters out redundant values before slice